### PR TITLE
Storage object updating correctly for addition/deletion of keys and nested documents. 

### DIFF
--- a/client/components/mongo/mongo.html
+++ b/client/components/mongo/mongo.html
@@ -73,10 +73,10 @@
       </div>
 
       <div>
-        <div ng-repeat="(key, val) in currentSchema['keys']">
+        <div ng-repeat="(key,val) in allKeys"> <!--currentSchema['keys']"> -->
           <hr>
-          <label>Key: {{key}}   Type: {{val.type}}</label>
-          <button "btn btn-default" ng-click="deleteKey(key, currentSchema)" class="pull-right">Delete Key</button>
+          <label>Key: {{key}} Type: {{val}}</label>
+          <button "btn btn-default" ng-click="deleteKey(key, val, allKeys)" class="pull-right">Delete Key</button>
           <br>
         </div>
       </div>

--- a/client/components/mongo/mongo.html
+++ b/client/components/mongo/mongo.html
@@ -119,7 +119,7 @@
           <input type="checkbox" ng-true-value="true" ng-false-value="false" ng-model="nestedDocument"/>
         </div>
 
-        <button "btn btn-default" ng-click="saveKey(keyName, keyValue, nestedDocument, nestedLocation); keyValue='0'; keyName=''; nestedDocument=false; nested='Main Document'" class="pull-right">Save Key</button>
+        <button "btn btn-default" ng-click="saveKey(keyName, keyValue, nestedDocument, nestedLocation); keyValue='0'; keyName=''; nestedDocument=undefined; nested='Main Document'" class="pull-right">Save Key</button>
         <br>
         <hr>
       </div>

--- a/client/components/mongo/mongo.html
+++ b/client/components/mongo/mongo.html
@@ -114,12 +114,17 @@
             <option>Array</option>
           </select>
         
-        <div ng-show="keyValue === 'Mixed'">
+        <div ng-show="keyValue === 'Mixed' && (depth[nestedLocation] == undefined || depth[nestedLocation] < 10)">
         <label>Nested document?<label>
           <input type="checkbox" ng-true-value="true" ng-false-value="false" ng-model="nestedDocument"/>
         </div>
 
-        <button "btn btn-default" ng-click="saveKey(keyName, keyValue, nestedDocument, nestedLocation); keyValue='0'; keyName=''; nestedDocument=undefined; nested='Main Document'" class="pull-right">Save Key</button>
+        <div ng-show="keyValue === 'Mixed' && depth[nestedLocation] === 10">
+          <br>
+          <p>Nested documents > 10 deep not supported.</p>
+        </div>
+
+        <button "btn btn-default" ng-click="saveKey(keyName, keyValue, nestedDocument, nestedLocation); keyValue='0'; keyName=''; nestedDocument=undefined; nestedLocation=nestedDocuments[0]" class="pull-right">Save Key</button>
         <br>
         <hr>
       </div>

--- a/client/components/mongo/mongo.html
+++ b/client/components/mongo/mongo.html
@@ -76,7 +76,7 @@
         <div ng-repeat="(key,val) in allKeys"> <!--currentSchema['keys']"> -->
           <hr>
           <label>Key: {{key}} Type: {{val}}</label>
-          <button "btn btn-default" ng-click="deleteKey(key, val, allKeys)" class="pull-right">Delete Key</button>
+          <button "btn btn-default" ng-click="deleteKey(key, val)" class="pull-right">Delete Key</button>
           <br>
         </div>
       </div>

--- a/client/components/output/mongoController.js
+++ b/client/components/output/mongoController.js
@@ -15,9 +15,13 @@ angular.module('DTBS.main')
     $scope.id = 0;
 
     //Not sure about how this will be used for nested objects yet. *************************
-    $scope.currentNested = '';
+    //$scope.currentNested = ''; //don't know why i had this here
+
+    //have to remember to reset everything to initial values in the resetAndUpdate() function
+    //$scope.nestedLevels = {}; //this will use location as a key and then the length of the location as the value, used for turning on message that
+                              //nesting > 10 is not supported
     $scope.nestedDocuments = ['Main Document']; 
-    $scope.nestedLocation = $scope.nestedDocuments[0];
+    $scope.nestedLocation = 'Main Document';//$scope.nestedDocuments[0]; this sets initial value of the select box
 
 
     //Variables used to show/hide form fields and d3/canvas elements.
@@ -64,33 +68,35 @@ angular.module('DTBS.main')
     //Save each key/value pair to the currentSchema object when save key button is pressed.
     $scope.saveKey = function (name, value, nested, location) {
 
-      $scope.currentSchema['keys'][name] = {type: value};
-      console.log(location);
-      //if type is mixed and it is a nested document, add a keys object to the key that is being saved to currentSchema
-
-      //pass in an array to a function. for each item in the array add ['keys'][argument] to $scope.currentSchema
-
-      if (location !== 'Main Document'){
-        //potentially make another function here that takes split(from below), passes it into the function, and then in a hardcoded way
-        //makes the correct path for insertion of the key/value pair
-        console.log('not!');
-      } 
-
-      }
-
+      var insertValue;
+      var currentLocation = location.split(' > ');
+      var currentDepth = currentLocation.length;
 
       if (nested){
-        $scope.currentSchema['keys'][name]['keys'] = {};
+        insertValue = {type: 'Nested Document', keys: {}};
         $scope.nestedDocuments.push(location + ' > ' + name);
-        //$scope.currentLocation = 
-        var split = $scope.nestedDocuments[$scope.nestedDocuments.length - 1].split(' > ');
-        console.log(split);
-        console.log(split.length);
-        console.log($scope.nestedDocuments);
+      } else {
+        insertValue = {type: value};
       }
-      //if location != 'Main Document' then some way to nest the key and value pair
 
-      //else
+
+
+      if (location === 'Main Document'){
+        $scope.currentSchema['keys'][name] = insertValue; 
+      } else {}
+
+      // if (nested){
+      //   $scope.currentSchema['keys'][name] = {};
+      //   $scope.currentSchema['keys'][name]['keys'] = {};
+      //   console.log($scope.currentSchema['keys'][name]);
+      //   $scope.nestedDocuments.push(location + ' > ' + name);
+      //   //$scope.currentLocation = 
+      //   var split = $scope.nestedDocuments[$scope.nestedDocuments.length - 1].split(' > ');
+      //   console.log(split);
+      //   console.log(split.length);
+      //   console.log($scope.nestedDocuments);
+      // }
+
       $scope.addingKey = false;
       console.log($scope.currentSchema);
     

--- a/client/components/output/mongoController.js
+++ b/client/components/output/mongoController.js
@@ -9,17 +9,24 @@ angular.module('DTBS.main')
 
     //Object to store current collection of schemas.
     $scope.schemaStorage = {};
+
     //Object for storing schema that is being created or edited.
     $scope.currentSchema = {keys: {}}; 
+
     //Unique number used as key for each schema saved to $scope.schemaStorage.
     $scope.id = 0;
     //Depth information 
-    $scope.depth = { 'Main Document': 1};
+
+    $scope.depth = { 'Main': 1};
     //Array of choices for location
-    $scope.nestedDocuments = ['Main Document'];
+
+    $scope.nestedDocuments = ['Main'];
+
+    //Object used to track location of keys for deleting purposes
+    $scope.allKeys = {};
 
     //set initial value of location select box
-    $scope.nestedLocation = 'Main Document';
+    $scope.nestedLocation = 'Main';
 
     //Variables used to show/hide form fields and d3/canvas elements.
     $scope.typeEdit = 'none'; 
@@ -49,6 +56,7 @@ angular.module('DTBS.main')
           $scope.currentSchema = $scope.schemaStorage[key];
           $scope.depth = $scope.schemaStorage[key]['depth'];
           $scope.nestedDocuments = $scope.schemaStorage[key]['nestedDocuments'];
+          $scope.allKeys = $scope.schemaStorage[key]['allKeys'];
           $scope.edit = true;
           $scope.showAddKey = true;
         }
@@ -72,16 +80,22 @@ angular.module('DTBS.main')
       var insertValue;
       var currentLocation = location.split(' > ');
       var currentDepth = currentLocation.length;
+      // console.log(value);
+      // $scope.allKeys[name] = value + ' Location: ' + location;
+      // console.log($scope.allKeys);
+      //make one more object that holds name and location, refer to that for editing?
 
       if (nested){
 
         insertValue = {type: 'Nested Document', keys: {}};
         $scope.nestedDocuments.push(location + ' > ' + name);
         $scope.depth[$scope.nestedDocuments[$scope.nestedDocuments.length - 1]] = currentDepth + 1;
-
       } else {
         insertValue = {type: value};
       }
+
+      $scope.allKeys[name] = insertValue.type + ' Location: ' + location;
+      console.log($scope.allKeys);
       console.log(currentLocation);//gives the array of values
       console.log(currentDepth);
 
@@ -109,14 +123,15 @@ angular.module('DTBS.main')
    
       $scope.addingKey = false;
       console.log($scope.currentSchema);
-    
     };
 
     //Delete key/value pairs on the currentSchema object when delete key button is pressed.
     $scope.deleteKey = function (keyName, schema) {
 
       //**************** need functionality for deleting nested keys
-      delete $scope.currentSchema['keys'][keyName];
+      //use location info contained in allkeys[keyName] to find thing to delete
+      //need to remove the keyname from allKeys object
+      //delete $scope.currentSchema['keys'][keyName];
     };
   
     //Delete the selected schema from the storage object if present.  
@@ -134,15 +149,19 @@ angular.module('DTBS.main')
         $scope.schemaStorage[$scope.currentSchema['id']] = $scope.currentSchema;
         $scope.schemaStorage[$scope.currentSchema['id']]['depth'] = $scope.depth;
         $scope.schemaStorage[$scope.currentSchema['id']]['nestedDocuments'] = $scope.nestedDocuments;
+        $scope.schemaStorage[$scope.currentSchema['id']]['allKeys'] = $scope.allKeys;
 
       } else if ($scope.currentSchema['id'] === undefined) {
         $scope.currentSchema['id'] = $scope.id;
         $scope.schemaStorage[$scope.id] = $scope.currentSchema; 
         $scope.schemaStorage[$scope.id]['depth'] = $scope.depth;
         $scope.schemaStorage[$scope.id]['nestedDocuments'] = $scope.nestedDocuments;
+        $scope.schemaStorage[$scope.id]['allKeys'] = $scope.allKeys;
         $scope.id++;
       }
       $scope.resetAndUpdate();
+
+      console.log($scope.schemaStorage);
     };
 
     //reset variables, hide form elements and modal, update d3
@@ -150,8 +169,9 @@ angular.module('DTBS.main')
 
       //reset currentSchema, depth, and nested documents array.  Hide form elements and modal.
       $scope.currentSchema = {keys: {}};
-      $scope.depth = { 'Main Document': 1};
-      $scope.nestedDocuments = ['Main Document'];
+      $scope.depth = { 'Main': 1};
+      $scope.nestedDocuments = ['Main'];
+      $scope.allKeys = {};
       $scope.edit = false;    
       $scope.showAddKey = false;
       $scope.addingKey = false;

--- a/client/components/output/mongoController.js
+++ b/client/components/output/mongoController.js
@@ -13,16 +13,13 @@ angular.module('DTBS.main')
     $scope.currentSchema = {keys: {}}; 
     //Unique number used as key for each schema saved to $scope.schemaStorage.
     $scope.id = 0;
+    //Depth information 
+    $scope.depth = { 'Main Document': 1};
+    //Array of choices for location
+    $scope.nestedDocuments = ['Main Document'];
 
-    //Not sure about how this will be used for nested objects yet. *************************
-    //$scope.currentNested = ''; //don't know why i had this here
-
-    //have to remember to reset everything to initial values in the resetAndUpdate() function
-    //$scope.nestedLevels = {}; //this will use location as a key and then the length of the location as the value, used for turning on message that
-                              //nesting > 10 is not supported
-    $scope.nestedDocuments = ['Main Document']; 
-    $scope.nestedLocation = 'Main Document';//$scope.nestedDocuments[0]; this sets initial value of the select box
-
+    //set initial value of location select box
+    $scope.nestedLocation = 'Main Document';
 
     //Variables used to show/hide form fields and d3/canvas elements.
     $scope.typeEdit = 'none'; 
@@ -49,6 +46,11 @@ angular.module('DTBS.main')
       for (var key in $scope.schemaStorage){
         if ($scope.schemaStorage[key]["name"] === schemaName){
           $scope.currentSchema = $scope.schemaStorage[key];
+          //add reference to location object here
+          $scope.depth = $scope.schemaStorage[key]['depth'];
+          console.log($scope.depth, 'depth once current schema is loaded up');
+          $scope.nestedDocuments = $scope.schemaStorage[key]['nestedDocuments'];
+          console.log($scope.nestedDocuments, 'nested documents array once current schema loaded up');
           $scope.edit = true;
           $scope.showAddKey = true;
         }
@@ -69,33 +71,23 @@ angular.module('DTBS.main')
     $scope.saveKey = function (name, value, nested, location) {
 
       var insertValue;
-      var currentLocation = location.split(' > ');
-      var currentDepth = currentLocation.length;
+
+      console.log($scope.depth, 'here is the depth object');
 
       if (nested){
         insertValue = {type: 'Nested Document', keys: {}};
+        var currentLocation = location.split(' > ');
+        var currentDepth = currentLocation.length;
         $scope.nestedDocuments.push(location + ' > ' + name);
+        $scope.depth[$scope.nestedDocuments[$scope.nestedDocuments.length - 1]] = currentDepth + 1;
       } else {
         insertValue = {type: value};
       }
 
+      
+      $scope.currentSchema['keys'][name] = insertValue; 
+   
 
-
-      if (location === 'Main Document'){
-        $scope.currentSchema['keys'][name] = insertValue; 
-      } else {}
-
-      // if (nested){
-      //   $scope.currentSchema['keys'][name] = {};
-      //   $scope.currentSchema['keys'][name]['keys'] = {};
-      //   console.log($scope.currentSchema['keys'][name]);
-      //   $scope.nestedDocuments.push(location + ' > ' + name);
-      //   //$scope.currentLocation = 
-      //   var split = $scope.nestedDocuments[$scope.nestedDocuments.length - 1].split(' > ');
-      //   console.log(split);
-      //   console.log(split.length);
-      //   console.log($scope.nestedDocuments);
-      // }
 
       $scope.addingKey = false;
       console.log($scope.currentSchema);
@@ -121,25 +113,32 @@ angular.module('DTBS.main')
 
       if ($scope.edit === true){  
         $scope.schemaStorage[$scope.currentSchema['id']] = $scope.currentSchema;
+        $scope.schemaStorage[$scope.currentSchema['id']]['depth'] = $scope.depth;
+        $scope.schemaStorage[$scope.currentSchema['id']]['nestedDocuments'] = $scope.nestedDocuments;
 
       } else if ($scope.currentSchema['id'] === undefined) {
         $scope.currentSchema['id'] = $scope.id;
         $scope.schemaStorage[$scope.id] = $scope.currentSchema; 
+        $scope.schemaStorage[$scope.id]['depth'] = $scope.depth;
+        $scope.schemaStorage[$scope.id]['nestedDocuments'] = $scope.nestedDocuments;
         $scope.id++;
       }
-
+      console.log($scope.schemaStorage, 'check to see that depth and nesting are included');
       $scope.resetAndUpdate();
     };
 
     //reset variables, hide form elements and modal, update d3
     $scope.resetAndUpdate = function () { 
 
-      //reset currentSchema, hide form elements and modal.
+      //reset currentSchema, depth, and nested documents array.  Hide form elements and modal.
       $scope.currentSchema = {keys: {}};
+      $scope.depth = { 'Main Document': 1};
+      $scope.nestedDocuments = ['Main Document'];
       $scope.edit = false;    
       $scope.showAddKey = false;
       $scope.addingKey = false;
       $scope.toggleEditModal('none');
+
 
       //update visualization
       $scope.interactCanvas();

--- a/client/components/output/mongoController.js
+++ b/client/components/output/mongoController.js
@@ -132,27 +132,47 @@ angular.module('DTBS.main')
       var location = val.split(': ');
       var locateString = location[1];
       var locateArray = locateString.split(' > ');
+      console.log(locateArray, 'this is the passed in location array'); //this also has the keys in it from index 1 to the end.
       var locateDepth = locateArray.length;
-      //fix nested documents
+      var keyList = [];
 
-      console.log($scope.allKeys);
-      //delete all keys from $scope.allKeys that are nested in the item being deleted
-      for (var item in $scope.allKeys){
-        var place = $scope.allKeys[item].split(': ');
-        console.log(place);
-        var placeString = place[1];
-        var placeArray = placeString.split(' > ');
-        console.log(placeArray);
-        console.log(locateArray);
-        if (placeArray === locateArray || placeArray.slice(0, locateDepth) === locateArray) {
-          delete $scope.allKeys[item];
+      console.log($scope.nestedDocuments, 'nestedDocuments at beginning');
+      //Delete potential locations for keys to be placed by altering $scope.nestedDocuments array
+      for (var i = 1; i < $scope.nestedDocuments.length; i++) {
+
+        var savedLocationArray = $scope.nestedDocuments[i].split(' > ');
+        console.log(savedLocationArray, 'this is the saved location array');
+
+        if (savedLocationArray.length >= locateArray.length){
+          console.log('right length to do something');
+          for (var j = 1; j < locateArray.length; j++){
+            if (savedLocationArray[j] !== locateArray[j]){
+              break;
+            }
+            if (j === locateArray.length - 1){
+              console.log(savedLocationArray, locateArray, 'this should show if these are the same');
+              if (savedLocationArray.length > locateArray.length){
+                //get all the keys in this length and store them so they can be deleted
+                keyList = keyList.concat(savedLocationArray.slice(locateArray.length));
+                console.log(keyList, 'here is a list of keys to delete from All Keys');
+              }
+              $scope.nestedDocuments.splice(i, 1);
+              i--;
+              console.log($scope.nestedDocuments, 'nestedDocuments at end');
+            }
+          }
         }
       }
-      console.log($scope.allKeys);
-      //need to remove from nestedDocuments list as well, can build a list of that as we go along with the above.
-      // for (var i = 1; i < nestedDocuments.length; i++){
 
-      // }
+     //Delete references to keys nested inside of deleted key - removes key from list of keys that can be edited in the schema.
+     console.log($scope.allKeys, 'before deleting');
+     for (var i = 1; i < keyList.length; i++){
+       if (keyList[i] !== 'Main'){
+        delete $scope.allKeys[keyList[i]];
+       }      
+     }
+     console.log($scope.allKeys, 'after deleting'); 
+
 
       if (locateDepth === 1){
         delete $scope.currentSchema['keys'][key]; 
@@ -176,7 +196,7 @@ angular.module('DTBS.main')
         delete $scope.currentSchema['keys'][locateArray[1]]['keys'][locateArray[2]]['keys'][locateArray[3]]['keys'][locateArray[4]]['keys'][locateArray[5]]['keys'][locateArray[6]]['keys'][locateArray[7]]['keys'][locateArray[8]]['keys'][locateArray[9]]['keys'][key];
       }
 
-      delete $scope.allKeys[key];
+      keyList = [];
 
     };
   

--- a/client/components/output/mongoController.js
+++ b/client/components/output/mongoController.js
@@ -132,47 +132,47 @@ angular.module('DTBS.main')
       var location = val.split(': ');
       var locateString = location[1];
       var locateArray = locateString.split(' > ');
-      console.log(locateArray, 'this is the passed in location array'); //this also has the keys in it from index 1 to the end.
       var locateDepth = locateArray.length;
       var keyList = [];
 
-      console.log($scope.nestedDocuments, 'nestedDocuments at beginning');
       //Delete potential locations for keys to be placed by altering $scope.nestedDocuments array
-      for (var i = 1; i < $scope.nestedDocuments.length; i++) {
 
-        var savedLocationArray = $scope.nestedDocuments[i].split(' > ');
-        console.log(savedLocationArray, 'this is the saved location array');
+      //******  there is a bug in here *************
+      if (locateArray.length > 1 || $scope.nestedDocuments.length > 1){
+        for (var i = 1; i < $scope.nestedDocuments.length; i++) {
 
-        if (savedLocationArray.length >= locateArray.length){
-          console.log('right length to do something');
-          for (var j = 1; j < locateArray.length; j++){
-            if (savedLocationArray[j] !== locateArray[j]){
-              break;
-            }
-            if (j === locateArray.length - 1){
-              console.log(savedLocationArray, locateArray, 'this should show if these are the same');
-              if (savedLocationArray.length > locateArray.length){
-                //get all the keys in this length and store them so they can be deleted
-                keyList = keyList.concat(savedLocationArray.slice(locateArray.length));
-                console.log(keyList, 'here is a list of keys to delete from All Keys');
+          var savedLocationArray = $scope.nestedDocuments[i].split(' > ');
+
+          if (savedLocationArray.length >= locateArray.length){
+
+            for (var j = 1; j < locateArray.length; j++){
+              if (savedLocationArray[j] !== locateArray[j]){
+                break;
               }
-              $scope.nestedDocuments.splice(i, 1);
-              i--;
-              console.log($scope.nestedDocuments, 'nestedDocuments at end');
+              if (j === locateArray.length - 1){
+
+                //if (savedLocationArray.length > locateArray.length){
+
+                  //get all the keys in this length and store them so they can be deleted
+                  keyList = keyList.concat(savedLocationArray.slice(locateArray.length));
+
+                //}
+
+                $scope.nestedDocuments.splice(i, 1);
+                i--;
+              }
             }
           }
         }
+        //Delete references to keys nested inside of deleted key - removes key from list of keys that can be edited in the schema.
+        for (var i = 1; i < keyList.length; i++){
+          if (keyList[i] !== 'Main'){
+            delete $scope.allKeys[keyList[i]];
+          }      
+        }
+        keyList = []; 
       }
-
-     //Delete references to keys nested inside of deleted key - removes key from list of keys that can be edited in the schema.
-     console.log($scope.allKeys, 'before deleting');
-     for (var i = 1; i < keyList.length; i++){
-       if (keyList[i] !== 'Main'){
-        delete $scope.allKeys[keyList[i]];
-       }      
-     }
-     console.log($scope.allKeys, 'after deleting'); 
-
+      //******  there is a bug above ***********
 
       if (locateDepth === 1){
         delete $scope.currentSchema['keys'][key]; 
@@ -196,7 +196,7 @@ angular.module('DTBS.main')
         delete $scope.currentSchema['keys'][locateArray[1]]['keys'][locateArray[2]]['keys'][locateArray[3]]['keys'][locateArray[4]]['keys'][locateArray[5]]['keys'][locateArray[6]]['keys'][locateArray[7]]['keys'][locateArray[8]]['keys'][locateArray[9]]['keys'][key];
       }
 
-      keyList = [];
+      delete $scope.allKeys[key];
 
     };
   

--- a/client/components/output/mongoController.js
+++ b/client/components/output/mongoController.js
@@ -126,12 +126,58 @@ angular.module('DTBS.main')
     };
 
     //Delete key/value pairs on the currentSchema object when delete key button is pressed.
-    $scope.deleteKey = function (keyName, schema) {
+    $scope.deleteKey = function (key, val) {
 
-      //**************** need functionality for deleting nested keys
-      //use location info contained in allkeys[keyName] to find thing to delete
-      //need to remove the keyname from allKeys object
-      //delete $scope.currentSchema['keys'][keyName];
+      //first, process val to get location information
+      var location = val.split(': ');
+      var locateString = location[1];
+      var locateArray = locateString.split(' > ');
+      var locateDepth = locateArray.length;
+      //fix nested documents
+
+      console.log($scope.allKeys);
+      //delete all keys from $scope.allKeys that are nested in the item being deleted
+      for (var item in $scope.allKeys){
+        var place = $scope.allKeys[item].split(': ');
+        console.log(place);
+        var placeString = place[1];
+        var placeArray = placeString.split(' > ');
+        console.log(placeArray);
+        console.log(locateArray);
+        if (placeArray === locateArray || placeArray.slice(0, locateDepth) === locateArray) {
+          delete $scope.allKeys[item];
+        }
+      }
+      console.log($scope.allKeys);
+      //need to remove from nestedDocuments list as well, can build a list of that as we go along with the above.
+      // for (var i = 1; i < nestedDocuments.length; i++){
+
+      // }
+
+      if (locateDepth === 1){
+        delete $scope.currentSchema['keys'][key]; 
+      } else if (locateDepth === 2) {
+        delete $scope.currentSchema['keys'][locateArray[1]]['keys'][key];
+      } else if (locateDepth === 3) {
+        delete $scope.currentSchema['keys'][locateArray[1]]['keys'][locateArray[2]]['keys'][key];
+      } else if (locateDepth === 4) {
+        delete $scope.currentSchema['keys'][locateArray[1]]['keys'][locateArray[2]]['keys'][locateArray[3]]['keys'][key];
+      } else if (locateDepth === 5) {
+        delete $scope.currentSchema['keys'][locateArray[1]]['keys'][locateArray[2]]['keys'][locateArray[3]]['keys'][locateArray[4]]['keys'][key];
+      } else if (locateDepth === 6) {
+        delete $scope.currentSchema['keys'][locateArray[1]]['keys'][locateArray[2]]['keys'][locateArray[3]]['keys'][locateArray[4]]['keys'][locateArray[5]]['keys'][key];
+      } else if (locateDepth === 7) { 
+        delete $scope.currentSchema['keys'][locateArray[1]]['keys'][locateArray[2]]['keys'][locateArray[3]]['keys'][locateArray[4]]['keys'][locateArray[5]]['keys'][locateArray[6]]['keys'][key];
+      } else if (locateDepth === 8) {
+        delete $scope.currentSchema['keys'][locateArray[1]]['keys'][locateArray[2]]['keys'][locateArray[3]]['keys'][locateArray[4]]['keys'][locateArray[5]]['keys'][locateArray[6]]['keys'][locateArray[7]]['keys'][key];
+      } else if (locateDepth === 9) {
+        delete $scope.currentSchema['keys'][locateArray[1]]['keys'][locateArray[2]]['keys'][locateArray[3]]['keys'][locateArray[4]]['keys'][locateArray[5]]['keys'][locateArray[6]]['keys'][locateArray[7]]['keys'][locateArray[8]]['keys'][key];
+      } else if (locateDepth === 10) {
+        delete $scope.currentSchema['keys'][locateArray[1]]['keys'][locateArray[2]]['keys'][locateArray[3]]['keys'][locateArray[4]]['keys'][locateArray[5]]['keys'][locateArray[6]]['keys'][locateArray[7]]['keys'][locateArray[8]]['keys'][locateArray[9]]['keys'][key];
+      }
+
+      delete $scope.allKeys[key];
+
     };
   
     //Delete the selected schema from the storage object if present.  

--- a/client/components/output/mongoController.js
+++ b/client/components/output/mongoController.js
@@ -40,17 +40,15 @@ angular.module('DTBS.main')
       $scope.visibleEditModal = !$scope.visibleEditModal;
     };
 
-    //Setting a schema during editing to the currentSchema object.
+    //Setting all relevant variables to the selected schema's information during editing.
     $scope.setSchema = function (schemaName) {
 
       for (var key in $scope.schemaStorage){
         if ($scope.schemaStorage[key]["name"] === schemaName){
+
           $scope.currentSchema = $scope.schemaStorage[key];
-          //add reference to location object here
           $scope.depth = $scope.schemaStorage[key]['depth'];
-          console.log($scope.depth, 'depth once current schema is loaded up');
           $scope.nestedDocuments = $scope.schemaStorage[key]['nestedDocuments'];
-          console.log($scope.nestedDocuments, 'nested documents array once current schema loaded up');
           $scope.edit = true;
           $scope.showAddKey = true;
         }
@@ -67,12 +65,11 @@ angular.module('DTBS.main')
       $scope.addingKey = true;
     };
 
-    //Save each key/value pair to the currentSchema object when save key button is pressed.
+    //Save each key/value pair to the correct location in the currentSchema object when save key button is pressed.
+    //update depth and nestedDocuments
     $scope.saveKey = function (name, value, nested, location) {
 
       var insertValue;
-
-      console.log($scope.depth, 'here is the depth object');
 
       if (nested){
         insertValue = {type: 'Nested Document', keys: {}};
@@ -80,11 +77,13 @@ angular.module('DTBS.main')
         var currentDepth = currentLocation.length;
         $scope.nestedDocuments.push(location + ' > ' + name);
         $scope.depth[$scope.nestedDocuments[$scope.nestedDocuments.length - 1]] = currentDepth + 1;
+
       } else {
         insertValue = {type: value};
       }
+  
+      //Here is where we have to actually insert in the values in the different levels 
 
-      
       $scope.currentSchema['keys'][name] = insertValue; 
    
 
@@ -123,7 +122,6 @@ angular.module('DTBS.main')
         $scope.schemaStorage[$scope.id]['nestedDocuments'] = $scope.nestedDocuments;
         $scope.id++;
       }
-      console.log($scope.schemaStorage, 'check to see that depth and nesting are included');
       $scope.resetAndUpdate();
     };
 
@@ -138,7 +136,6 @@ angular.module('DTBS.main')
       $scope.showAddKey = false;
       $scope.addingKey = false;
       $scope.toggleEditModal('none');
-
 
       //update visualization
       $scope.interactCanvas();

--- a/client/components/output/mongoController.js
+++ b/client/components/output/mongoController.js
@@ -65,11 +65,32 @@ angular.module('DTBS.main')
     $scope.saveKey = function (name, value, nested, location) {
 
       $scope.currentSchema['keys'][name] = {type: value};
-
+      console.log(location);
       //if type is mixed and it is a nested document, add a keys object to the key that is being saved to currentSchema
+
+      //pass in an array to a function. for each item in the array add ['keys'][argument] to $scope.currentSchema
+
+      if (location !== 'Main Document'){
+        //potentially make another function here that takes split(from below), passes it into the function, and then in a hardcoded way
+        //makes the correct path for insertion of the key/value pair
+        console.log('not!');
+      } 
+
+      }
+
+
       if (nested){
         $scope.currentSchema['keys'][name]['keys'] = {};
+        $scope.nestedDocuments.push(location + ' > ' + name);
+        //$scope.currentLocation = 
+        var split = $scope.nestedDocuments[$scope.nestedDocuments.length - 1].split(' > ');
+        console.log(split);
+        console.log(split.length);
+        console.log($scope.nestedDocuments);
       }
+      //if location != 'Main Document' then some way to nest the key and value pair
+
+      //else
       $scope.addingKey = false;
       console.log($scope.currentSchema);
     

--- a/client/components/output/mongoController.js
+++ b/client/components/output/mongoController.js
@@ -70,24 +70,43 @@ angular.module('DTBS.main')
     $scope.saveKey = function (name, value, nested, location) {
 
       var insertValue;
+      var currentLocation = location.split(' > ');
+      var currentDepth = currentLocation.length;
 
       if (nested){
+
         insertValue = {type: 'Nested Document', keys: {}};
-        var currentLocation = location.split(' > ');
-        var currentDepth = currentLocation.length;
         $scope.nestedDocuments.push(location + ' > ' + name);
         $scope.depth[$scope.nestedDocuments[$scope.nestedDocuments.length - 1]] = currentDepth + 1;
 
       } else {
         insertValue = {type: value};
       }
-  
-      //Here is where we have to actually insert in the values in the different levels 
+      console.log(currentLocation);//gives the array of values
+      console.log(currentDepth);
 
-      $scope.currentSchema['keys'][name] = insertValue; 
+      if (currentDepth === 1){
+        $scope.currentSchema['keys'][name] = insertValue; 
+      } else if (currentDepth === 2) {
+        $scope.currentSchema['keys'][currentLocation[1]]['keys'][name] = insertValue;
+      } else if (currentDepth === 3) {
+        $scope.currentSchema['keys'][currentLocation[1]]['keys'][currentLocation[2]]['keys'][name] = insertValue;
+      } else if (currentDepth === 4) {
+        $scope.currentSchema['keys'][currentLocation[1]]['keys'][currentLocation[2]]['keys'][currentLocation[3]]['keys'][name] = insertValue;
+      } else if (currentDepth === 5) {
+        $scope.currentSchema['keys'][currentLocation[1]]['keys'][currentLocation[2]]['keys'][currentLocation[3]]['keys'][currentLocation[4]]['keys'][name] = insertValue;
+      } else if (currentDepth === 6) {
+        $scope.currentSchema['keys'][currentLocation[1]]['keys'][currentLocation[2]]['keys'][currentLocation[3]]['keys'][currentLocation[4]]['keys'][currentLocation[5]]['keys'][name] = insertValue;
+      } else if (currentDepth === 7) { 
+        $scope.currentSchema['keys'][currentLocation[1]]['keys'][currentLocation[2]]['keys'][currentLocation[3]]['keys'][currentLocation[4]]['keys'][currentLocation[5]]['keys'][currentLocation[6]]['keys'][name] = insertValue;
+      } else if (currentDepth === 8) {
+        $scope.currentSchema['keys'][currentLocation[1]]['keys'][currentLocation[2]]['keys'][currentLocation[3]]['keys'][currentLocation[4]]['keys'][currentLocation[5]]['keys'][currentLocation[6]]['keys'][currentLocation[7]]['keys'][name] = insertValue;
+      } else if (currentDepth === 9) {
+        $scope.currentSchema['keys'][currentLocation[1]]['keys'][currentLocation[2]]['keys'][currentLocation[3]]['keys'][currentLocation[4]]['keys'][currentLocation[5]]['keys'][currentLocation[6]]['keys'][currentLocation[7]]['keys'][currentLocation[8]]['keys'][name] = insertValue;
+      } else if (currentDepth === 10) {
+        $scope.currentSchema['keys'][currentLocation[1]]['keys'][currentLocation[2]]['keys'][currentLocation[3]]['keys'][currentLocation[4]]['keys'][currentLocation[5]]['keys'][currentLocation[6]]['keys'][currentLocation[7]]['keys'][currentLocation[8]]['keys'][currentLocation[9]]['keys'][name] = insertValue;
+      }
    
-
-
       $scope.addingKey = false;
       console.log($scope.currentSchema);
     
@@ -96,6 +115,7 @@ angular.module('DTBS.main')
     //Delete key/value pairs on the currentSchema object when delete key button is pressed.
     $scope.deleteKey = function (keyName, schema) {
 
+      //**************** need functionality for deleting nested keys
       delete $scope.currentSchema['keys'][keyName];
     };
   


### PR DESCRIPTION
Bug identified:  When user deletes key that is a nested object containing other keys, information provided to user during editing (nested document locations available for adding keys to, keys available for deletion) is incorrect.  Storage object is correct for all cases tested.  Will work on resolving this issue.
